### PR TITLE
When data is null, we should not query any reference

### DIFF
--- a/src/Norm/Model.php
+++ b/src/Norm/Model.php
@@ -291,7 +291,7 @@ class Model implements \JsonKit\JsonSerializer, \ArrayAccess {
         $schema = $this->collection->schema();
 
         foreach($source as $key => $value) {
-            if (isset($schema[$key])) {
+            if (isset($schema[$key]) && !is_null($value)) {
                 $destination[$key] = $schema[$key]->toJSON($value);
             } else {
                 $destination[$key] = $value;


### PR DESCRIPTION
This happen when you want to search a reference that does not have a value a.k.a `null`.
