### PR TITLE
[ADD] Some overloading method.

### DIFF
--- a/src/Norm/Dialect/SQLDialect.php
+++ b/src/Norm/Dialect/SQLDialect.php
@@ -173,8 +173,6 @@ abstract class SQLDialect
         $data[$fk] = $fValue;
 
         return $this->grammarEscape($field).' '.$operator.' :'.$fk;
-
-
     }
 
     public function grammarInsert($collectionName, $data)

--- a/src/Norm/Model.php
+++ b/src/Norm/Model.php
@@ -1,11 +1,11 @@
-<?php
-
-namespace Norm;
+<?php namespace Norm;
 
 use Closure;
 use Norm\Norm;
 use Exception;
+use ArrayAccess;
 use JsonKit\JsonKit;
+use JsonKit\JsonSerializer;
 
 /**
  * Base class for hookable implementation
@@ -16,7 +16,7 @@ use JsonKit\JsonKit;
  * @license     https://raw.github.com/xinix-technology/norm/master/LICENSE
  * @package     Norm
  */
-class Model implements \JsonKit\JsonSerializer, \ArrayAccess
+class Model implements JsonSerializer, ArrayAccess
 {
 
     /**
@@ -27,8 +27,8 @@ class Model implements \JsonKit\JsonSerializer, \ArrayAccess
      */
     const FETCH_ALL       = 'FETCH_ALL';
     const FETCH_RAW       = 'FETCH_RAW';
-    const FETCH_PUBLISHED = 'FETCH_PUBLISHED';
     const FETCH_HIDDEN    = 'FETCH_HIDDEN';
+    const FETCH_PUBLISHED = 'FETCH_PUBLISHED';
 
     /**
      * State of document
@@ -37,9 +37,9 @@ class Model implements \JsonKit\JsonSerializer, \ArrayAccess
      * STATE_ATTACHED
      * STATE_REMOVED
      */
-    const STATE_DETACHED = 'STATE_DETACHED';
-    const STATE_ATTACHED = 'STATE_ATTACHED';
     const STATE_REMOVED  = 'STATE_REMOVED';
+    const STATE_ATTACHED = 'STATE_ATTACHED';
+    const STATE_DETACHED = 'STATE_DETACHED';
 
     /**
      * Collection object of model.
@@ -624,5 +624,41 @@ class Model implements \JsonKit\JsonSerializer, \ArrayAccess
     public function getClass()
     {
         return $this->collection->getClass();
+    }
+
+    /**
+     * Set an attribute value
+     *
+     * @param string $index
+     * @param mized  $value
+     *
+     * @return void
+     */
+    public function __set($index, $value = '')
+    {
+        return $this->set($index, $value);
+    }
+
+    /**
+     * Get an attribute value
+     *
+     * @param string $index
+     * @param mixed  $default Default value if index doesn't exist
+     *
+     * @return mixed
+     */
+    public function __get($index)
+    {
+        return $this->get($index);
+    }
+
+   /**
+     * Convert your collection to JSON
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return json_encode($this->jsonSerialize());
     }
 }

--- a/src/Norm/Test/Driver/AbstractCursorTest.php
+++ b/src/Norm/Test/Driver/AbstractCursorTest.php
@@ -27,6 +27,13 @@ abstract class AbstractCursorTest extends \PHPUnit_Framework_TestCase
             'first_name' => 'pendi',
             'last_name' => 'setiawan',
         ),
+        array(
+            'first_name' => 'wahyu',
+            'last_name' => 'pribadi',
+        ),array(
+            'first_name' => 'wahyu',
+            'last_name' => 'taufik',
+        ),
     );
 
     abstract public function getConnection();
@@ -117,7 +124,7 @@ abstract class AbstractCursorTest extends \PHPUnit_Framework_TestCase
         $limit = $cursor->limit();
 
         $message = 'Cursor::limit() expected count() to be 3';
-        $this->assertEquals(3, $cursor->count(), $message);
+        $this->assertEquals(count($this->fixtures), $cursor->count(), $message);
 
         $message = 'Cursor::limit() expected count(true) to be 1';
         $this->assertEquals(1, $cursor->count(true), $message);
@@ -139,10 +146,10 @@ abstract class AbstractCursorTest extends \PHPUnit_Framework_TestCase
         $skip = $cursor->skip();
 
         $message = 'Cursor::skip() expected count() to be 3';
-        $this->assertEquals(3, $cursor->count(), $message);
+        $this->assertEquals(count($this->fixtures), $cursor->count(), $message);
 
         $message = 'Cursor::skip() expected count(true) to be 1';
-        $this->assertEquals(2, $cursor->count(true), $message);
+        $this->assertEquals(count($this->fixtures) - 1, $cursor->count(true), $message);
 
         $message = 'Cursor::skip() expected return chainable object';
         $this->assertEquals($cursor, $result, $message);

--- a/test/Norm/Test/Driver/MySql/MySqlPDOCursorTest.php
+++ b/test/Norm/Test/Driver/MySql/MySqlPDOCursorTest.php
@@ -26,4 +26,36 @@ class MySqlPDOCursorTest extends AbstractCursorTest
 
         return $this->connection;
     }
+
+    public function testQueryIn()
+    {
+        $collection = $this->connection->factory($this->collection->getClass())->find(array(
+            'first_name!in' => array('wahyu', 'farid')
+        ));
+
+        $this->assertEquals($collection->count(true), 3);
+
+        $model = $collection->getNext();
+
+        $this->assertEquals($model->first_name, 'farid');
+        $this->assertEquals($model->last_name, 'hidayat');
+
+        $model = $collection->getNext();
+
+        $this->assertNotEquals($model->first_name, 'farid');
+        $this->assertNotEquals($model->last_name, 'hidayat');
+
+        $this->assertEquals($model->first_name, 'wahyu');
+        $this->assertEquals($model->last_name, 'pribadi');
+
+        $model = $collection->getNext();
+
+        $this->assertEquals($model->first_name, 'wahyu');
+        $this->assertNotEquals($model->last_name, 'pribadi');
+
+        $this->assertEquals($model->first_name, 'wahyu');
+        $this->assertEquals($model->last_name, 'taufik');
+
+        $this->assertTrue(is_null($collection->getNext()));
+    }
 }

--- a/test/Norm/Test/ModelTest.php
+++ b/test/Norm/Test/ModelTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Norm\Test;
+
+use Norm\Collection;
+use Norm\Model;
+use Norm\Connection\MemoryConnection;
+use Norm\Schema\String;
+
+class ModelTest extends \PHPUnit_Framework_TestCase
+{
+    protected $schema;
+
+    protected $collection;
+
+    protected $connection;
+
+    public function setUp()
+    {
+        $this->schema = array(
+            'field_a' => String::create('field_a'),
+            'field_b' => String::create('field_b')->filter('trim'),
+        );
+
+        $this->connection = new MemoryConnection(array(
+            'name' => 'test_connection',
+        ));
+
+        $this->connection->setCollectionData('test_collection', array(
+            array(
+                'field_a' => 'a1',
+                'field_b' => 'b1',
+            ),
+        ));
+
+        $this->collection = new Collection(array(
+            'name' => 'TestCollection',
+            'schema' => $this->schema,
+            'connection' => $this->connection,
+        ));
+    }
+
+    public function testInstance()
+    {
+        $model = $this->collection->findOne();
+
+        $this->assertInstanceOf('Norm\Model', $model);
+    }
+
+    public function testGet()
+    {
+        $model = $this->collection->findOne();
+
+        $this->assertEquals($model->field_a, 'a1');
+
+        $this->assertEquals($model->get('field_a'), 'a1');
+
+        $this->assertEquals($model['field_a'], 'a1');
+    }
+
+    public function testSet()
+    {
+        $model = $this->collection->findOne();
+
+        $model->field_a = 'foo';
+        $this->assertEquals($model->field_a, 'foo');
+
+        $model->set('field_a', 'bar');
+        $this->assertEquals($model->get('field_a'), 'bar');
+
+        $model['field_a'] = 'baz';
+
+        $this->assertEquals($model['field_a'], 'baz');
+    }
+
+    public function testJson()
+    {
+        $model = $this->collection->findOne();
+
+        $firstJson = json_encode($model->jsonSerialize());
+        $secondJson = (string) $model;
+        $thirdJson = json_encode($model->toArray());
+
+        $this->assertTrue(is_string($firstJson));
+        $this->assertTrue(is_string($secondJson));
+        $this->assertTrue(is_string($thirdJson));
+
+        $this->assertEquals($firstJson, $secondJson);
+        $this->assertEquals($firstJson, $thirdJson);
+        $this->assertEquals($secondJson, $thirdJson);
+    }
+}


### PR DESCRIPTION
Now we can get `model` value using:

``` php
$foo = $model->some_field;
```

And set an attribute value using:

``` php
$model->some_field = 'foo';
```

I also add a method to convert a model to JSON representation by [type juggling](http://php.net/manual/en/language.types.type-juggling.php) the `model` to a [string](http://php.net/manual/en/language.types.string.php).
